### PR TITLE
Master

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<()> {
     });
     let proxy = ServerProxy::new(&connection).await?;
     proxy.status().await.unwrap_or_else(|_|{
-        panic!("Server is not connected to the bust address, aborting..");
+        panic!("Mplayer server is not Up, aborting..");
     });
 
     init_panic_hook();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,11 +10,12 @@ pub trait StringFeatures {
 /// logs _data_ to a _file_ in a incremantive manner
 /// 
 /// Panics: 
-/// - if file does not exist
+/// - failed to create or write to the file
 pub fn log(data: &str, filename: &str) -> std::io::Result<std::fs::File>{
     let mut f = OpenOptions::new()
         .write(true)
         .append(true)
+        .create(true)
         .open(filename)?;
     writeln!(f, "{}", data)?;
     return std::io::Result::Ok(f)


### PR DESCRIPTION
- `log` function now creates a log file if one does not exist 17c271471a90e7c702924e2f844f20b1b13764f6
- more relevant error message is now displayed if the dbus server is not up (from `Server is not connected to the bust address, aborting..` to `Mplayer server is not Up, aborting..`) 6bd51a72118dda82c1df784c8fa56d05f7f5a9e8