### PR TITLE
Incorporate new commands and playlist features

### DIFF
--- a/About.norg
+++ b/About.norg
@@ -16,3 +16,22 @@
   ~ ( ) navigate through .mu3 playlists from the config file
   ~ ( ) It would be nice to have a keybind to add a music to a specific playlist
   ~~ ( ) It would be nice to display those playlists in a nice way
+  ~~ ( ) It would be nice to add a music to a certain playlist
+  ~~ ( ) It would be nice to delete a music from a certain playlist
+
+* Possible commands
+  - :playlists
+  - :select_playlist "playlist name"
+  - :add_to_playlist "playlist name"
+  - :next_region
+  - :previous_region
+  - :select_region region_name
+  - :scroll down
+  - :scroll up
+  - :toggle mute
+  - :toggle play
+  - :toggle lyrics
+
+  At first, we will have the commands input box and the playlists displayed in the list box (where lyrics is displayed) then we can have the following:
+  - :select_playlist shows the list with playlists thing
+  - :select_playlist <playlist-name> selects the playlist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "allocator-api2"
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -49,41 +49,41 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "async-lock"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
  "async-channel",
  "async-io",
@@ -105,8 +105,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 0.38.44",
- "tracing",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -122,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
  "async-io",
  "async-lock",
@@ -132,10 +131,10 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -146,9 +145,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -163,15 +162,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -179,7 +178,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -193,15 +192,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -234,27 +233,28 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "e1d05d92f4b1fd76aad469d46cdd858ca761576082cd37df81416691e50199fb"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -315,7 +315,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "mio 1.0.3",
+ "mio 1.0.4",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -381,9 +381,9 @@ checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
 name = "enumflags2"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -408,29 +408,30 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+checksum = "259d404d09818dec19332e31d94558aeb442fea04c817006456c24b5460bbd4b"
 dependencies = [
  "serde",
+ "serde_core",
  "typeid",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -452,6 +453,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0399f9d26e5191ce32c498bebd31e7a3ceabc2745f0ac54af3f335126c3f24b3"
 
 [[package]]
 name = "fnv"
@@ -515,9 +522,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -578,32 +585,38 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -613,9 +626,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -631,12 +644,12 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -647,15 +660,26 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -675,9 +699,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linux-raw-sys"
@@ -687,25 +711,24 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
@@ -713,14 +736,14 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -733,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -748,27 +771,27 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "mlua"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f763c1041eff92ffb5d7169968a327e1ed2ebfe425dac0ee5a35f29082534b"
+checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
 dependencies = [
  "bstr",
  "either",
@@ -777,15 +800,16 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "rustc-hash",
+ "rustversion",
  "serde",
  "serde-value",
 ]
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1901c1a635a22fe9250ffcc4fcc937c16b47c2e9e71adba8784af8bca1f69594"
+checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
 dependencies = [
  "cc",
  "cfg-if",
@@ -794,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "mplayer-client"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "basic-toml",
  "crossterm 0.27.0",
@@ -832,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -872,9 +896,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -882,15 +906,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -930,51 +954,50 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
-version = "3.7.4"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "ratatui"
@@ -1020,18 +1043,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -1054,22 +1077,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -1085,10 +1108,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -1103,10 +1127,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1132,9 +1165,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1148,42 +1181,39 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio 0.8.11",
- "mio 1.0.3",
+ "mio 1.0.4",
  "signal-hook",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1222,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1233,44 +1263,45 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.0.3",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
- "mio 1.0.3",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1286,18 +1317,31 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
+dependencies = [
  "winnow",
 ]
 
@@ -1314,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1325,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1361,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1396,17 +1440,26 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -1432,6 +1485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,20 +1501,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.52.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1581,26 +1640,23 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zbus"
-version = "5.7.1"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.11.0"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -1623,7 +1679,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -1632,8 +1688,8 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.7.1"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.11.0"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1647,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "zbus_names"
 version = "4.2.0"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "serde",
  "winnow",
@@ -1656,8 +1712,8 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.5.3"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.7.0"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "endi",
  "enumflags2",
@@ -1669,8 +1725,8 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.3"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "5.7.0"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1681,8 +1737,8 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.2.0"
-source = "git+https://github.com/dbus2/zbus?branch=main#3d7f80f677121948113fd507a43a0ea0a7d5a3f7"
+version = "3.2.1"
+source = "git+https://github.com/dbus2/zbus?branch=main#df446d261e34f71e5661e7d8fe86f65915f1eefa"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ ratatui = "0.28.0"
 serde = "1.0.204"
 tokio = { version = "1.44.1", features = ["full"] }
 tui-input = "0.11.0"
-zbus = { git = "https://github.com/dbus2/zbus", branch = "main", features = ["tokio"] }
+zbus = { version = "5.11.0", features = ["tokio"] }
 mlua = { version = "0.10.3", features = ["luajit", "serialize"] }

--- a/DOCS.md
+++ b/DOCS.md
@@ -17,13 +17,22 @@
 |List|Normal|`gg`|Go to the top of the list|
 |List|Normal|`G`|Go to the bottom of the list|
 |List|Normal|`/`|Enable `Search` mode|
+|List|Normal|`:`|Enable `Command` mode|
 |List|Search|`Character`|Register the character to the search querry, check [this](#Search_filters) for search tricks|
 |List|Search|`Enter`|Play the music under selection|
+|List|Command|`Character`|Register the character to the command querry, check [this](#commands) for available commands|
+|List|Command|`Enter`|Execute command|
 |List|Search|`Esc`|Enable `After Search` mode|
 |List|After Search|`j`|Scroll down|
 |List|After Search|`k`|Scroll up|
 |List|After Search|`Space` or `Enter`|Play the music under selection|
 |List|After Search|`p`|Toggle `play` for the currently playing song|
+|Playlist|Normal|`j`|Move down|
+|Playlist|Normal|`k`|Move up|
+|Playlist|Normal|`Enter`|Select current playlist|
+|Lyrics|Normal|`j`|Move down|
+|Lyrics|Normal|`k`|Move up|
+|Lyrics|Normal|`Enter`|Play music from line if possible|
 |Actions|Normal|`l`|Move right|
 |Actions|Normal|`h`|Move left|
 |Actions|Normal|`Space` or `Enter`|Apply selected action (available only for `next, previous, play and stop` actions)|
@@ -41,10 +50,24 @@
 
 |filter|description|
 |------|-----------|
-|`:title <title>`| serch by title |
-|`:artist <artist>`| search by artist |
-|`:duration <mm:ss>`| search by duration |
-|`:genre <genre>`| search by genre|
+|`:title <title>`| Serch by title |
+|`:artist <artist>`| Search by artist |
+|`:duration <mm:ss>`| Search by duration |
+|`:genre <genre>`| Search by genre|
+
+# Commands
+
+|filter|description|
+|------|-----------|
+|`:move <up/down>`|Moves the selection cursor up/down|
+|`:play`|Plays the selected playlist|
+|`:resume`|Resumes playing music|
+|`:add_to_playlist <playlist-name>`|Adds selected song to playlist|
+|`:create_playlist <playlist-name>`|Creates a new playlist|
+|`:rename_playlist <old-name> <new-name>`|Renames playlist with old name to new one (can't rename `default`) |
+|`:remove_playlist <playlist-name>`|Remove playlis by the name (can't remove `default` and requires reload to take effect)|
+|`:toggle_mute`|Toggle mute|
+|`:q` | `:quit`|Quit client|
 
 # Configuration
 
@@ -69,7 +92,7 @@ list = "/home/user/.config/mplayer-client/lua/list.lua"
 # volume = "/home/user/.config/mplayer-client/volume.lua"
 ```
 
-## config
+## Config
 
 |field|description|
 |------|-----------|
@@ -77,7 +100,7 @@ list = "/home/user/.config/mplayer-client/lua/list.lua"
 |`lyrics`| Display lyrics window be display whenever a client is opened (this does not disable it) |
 |`genre`| Display genre row in the music list |
 
-## scripts
+## Scripts
 
 Each script will run **after each key press** whenever it's corresponding **region is sellected**, and the `all` will run when any region is selected. 
 Each script should be a path to a lua script with the following format
@@ -103,6 +126,7 @@ end
 - Code: check `enum KCode` in `./src/ui.rs` cuz it's kinda too big.
 
 # Extra
+
 Check the example(s) in [`./examples/`](./examples) for inspiration
 >[!NOTE]
 > More funcitonal API will be provided in the future, like functions/methods that allows you to iterract with client programatically. if you think this deserves better, make a PR and I'll happily review it :3

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,16 @@
         pkgs = import <nixpkgs-unstable> { };
       in
       {
-        defaultPackage = naersk-lib.buildPackage ./.;
+        defaultPackage = naersk-lib.buildPackage {
+          name = "mplayer-client";
+          src = ./.;
+          buildInputs = with pkgs; [
+            pkg-config
+            luajit
+            luajitPackages.ldbus
+            rustc
+          ];
+        };
         devShell =
           with pkgs;
           mkShell {

--- a/src/allowed_commands.rs
+++ b/src/allowed_commands.rs
@@ -1,0 +1,79 @@
+use std::str::FromStr;
+
+pub struct CommandContext {
+    pub name: CommandName,
+    pub args: Vec<String>,
+}
+
+impl<'a> CommandContext {
+    pub fn new(name: CommandName, args: Vec<String>) -> Self {
+        Self { name, args }
+    }
+}
+
+#[derive(Debug)]
+pub enum CommandName {
+    Move,
+    Play,
+    Pause,
+    Resume,
+    Reload,
+    AddToPlaylist,
+    CreatePlaylist,
+    Quit,
+    ToggleMute,
+    RenamePlaylist,
+    RemovePlaylist,
+}
+
+impl CommandName {
+    pub fn number_of_required_args(&self) -> usize {
+        match self {
+            // no arguments
+            CommandName::Pause => 0,
+            // no arguments
+            CommandName::Resume => 0,
+            // no arguments
+            CommandName::Quit => 0,
+            // no arguments
+            CommandName::ToggleMute => 0,
+            // no arguments
+            CommandName::Reload=> 0,
+            // direction up/down
+            CommandName::Move => 1,
+            CommandName::Play => 1,
+            // playlist name
+            CommandName::AddToPlaylist => 1,
+            // playlist name
+            CommandName::CreatePlaylist => 1,
+            // Old and New names
+            CommandName::RenamePlaylist => 2,
+            // Playlist name
+            CommandName::RemovePlaylist => 1,
+        }
+    }
+}
+
+impl FromStr for CommandName {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "move" => Ok(Self::Move),
+            "play" => Ok(Self::Play),
+            "add_to_playlist" => Ok(Self::AddToPlaylist),
+            "create_playlist" => Ok(Self::CreatePlaylist),
+            "rename_playlist" => Ok(Self::RenamePlaylist),
+            "remove_playlist" => Ok(Self::RemovePlaylist),
+            "toggle_mute" => Ok(Self::ToggleMute),
+            "pause" => Ok(Self::Pause),
+            "reload" => Ok(Self::Reload),
+            "resume" => Ok(Self::Resume),
+            "q" | "quit" => Ok(Self::Quit),
+            _ => Err(std::io::Error::other(format!(
+                "Unkown command variant {}",
+                s
+            ))),
+        }
+    }
+}

--- a/src/fuzzy_search.rs
+++ b/src/fuzzy_search.rs
@@ -1,8 +1,8 @@
 #![allow(unused)]
+use crate::types::Music;
+use crate::ui::UI;
 use fuzzy_matcher::FuzzyMatcher;
 use std::cmp::Ordering;
-
-use crate::ui::{Music, UI};
 
 pub fn fuzzy_search_music_titles_best_n<'a>(
     s: &'a str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{
+    collections::HashMap,
     env,
     io::{self, stdout},
-    time::Duration,
 };
 
 use crossterm::{
@@ -10,189 +10,31 @@ use crossterm::{
     ExecutableCommand,
 };
 use parser::*;
-use ratatui::{backend::CrosstermBackend, text::Span, Terminal};
-use ui::Music;
+use ratatui::{backend::CrosstermBackend, Terminal};
+use types::Lyrics;
+use types::Metadata;
+use types::OuterMusic;
+use types::PlayerStatus;
+use types::PlayingStatus;
+use types::Playlist;
+use types::Repeat;
+use types::Sort;
 use utils::RunStatus;
-use zbus::{proxy, zvariant::FilePath, Connection, Result};
+use zbus::{proxy, Connection, Result};
 
+mod allowed_commands;
 mod fuzzy_search;
 mod parser;
 mod states;
+mod style;
+mod types;
 mod ui;
 mod utils;
 
 #[allow(unused_imports)]
 use utils::log;
 
-#[derive(serde::Deserialize, serde::Serialize, zbus::zvariant::Type, Debug, Default, Clone)]
-struct Picture {
-    data: Vec<u8>,
-    typ: String,
-}
-
-#[derive(
-    PartialEq, Eq, Debug, Clone, zbus::zvariant::Type, serde::Serialize, serde::Deserialize,
-)]
-pub struct Line {
-    content: String,
-    timestamp: Duration,
-}
-
-#[derive(
-    PartialEq, Eq, Debug, Clone, zbus::zvariant::Type, serde::Deserialize, serde::Serialize,
-)]
-pub struct Lyrics {
-    time_is_correct: bool,
-    lines: Vec<Line>,
-}
-
-impl Default for Line {
-    fn default() -> Self {
-        Line {
-            content: String::new(),
-            timestamp: Duration::ZERO,
-        }
-    }
-}
-
-impl Default for Lyrics {
-    fn default() -> Self {
-        Self {
-            time_is_correct: false,
-            lines: vec![],
-        }
-    }
-}
-
-#[derive(serde::Deserialize, serde::Serialize, zbus::zvariant::Type, Debug, Default, Clone)]
-pub struct Metadata {
-    title: String,
-    artis: String,
-    genre: String,
-    cover: Picture,
-    lyrics: Lyrics,
-}
-
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, Default, zbus::zvariant::Type)]
-pub enum PlayingStatus {
-    /// Pausing state
-    Playing,
-    /// Playing state
-    Pausing,
-    #[default]
-    /// Stopping state
-    Stopped,
-}
-
-#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, zbus::zvariant::Type)]
-pub struct PlayerStatus {
-    status: PlayingStatus,
-    music: OuterMusic,
-    /// between 0 and 1
-    volume: f32,
-    index: u32,
-}
-
-#[derive(
-    serde::Serialize,
-    serde::Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    Default,
-    zbus::zvariant::Type,
-    Eq,
-    PartialEq,
-)]
-pub enum Sort {
-    #[default]
-    /// Sort  by music title in ascending order
-    ByTitleAscending,
-    /// Sort by music title in descending order
-    ByTitleDescending,
-    /// Sort by music length in ascending order
-    ByDurationAscending,
-    /// Sort by music length in descending order
-    ByDurationDescending,
-    /// Sort by music artist name in ascending order
-    ArtistAscending,
-    /// Sort by music artist name in descending order
-    ArtistDescending,
-    // Sort at random
-    Shuffle,
-}
-
-impl Sort {
-    fn as_span(&self) -> Span {
-        match self {
-            Sort::ByTitleAscending => Span::from("TitleAscending"),
-            Sort::ByTitleDescending => Span::from("TitleDescending"),
-            Sort::ByDurationAscending => Span::from("DurationAscending"),
-            Sort::ByDurationDescending => Span::from("DurationDescending"),
-            Sort::ArtistAscending => Span::from("ArtistAscending"),
-            Sort::ArtistDescending => Span::from("ArtistDescending"),
-            Sort::Shuffle => Span::from("Shuffle"),
-        }
-    }
-}
-
-#[derive(
-    serde::Serialize,
-    serde::Deserialize,
-    Debug,
-    Clone,
-    Copy,
-    Default,
-    zbus::zvariant::Type,
-    Eq,
-    PartialEq,
-)]
-pub enum Repeat {
-    /// repeat the currently playing music
-    SameMusic,
-    #[default]
-    /// cycle through all the playlist
-    AllMusics,
-    /// stop after the currently playing music
-    Dont,
-}
-
-impl Repeat {
-    fn as_span(&self) -> Span {
-        match self {
-            Repeat::SameMusic => Span::from("RepeatMusic"),
-            Repeat::AllMusics => Span::from("RepeatList"),
-            Repeat::Dont => Span::from("NoRepeat"),
-        }
-    }
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, zbus::zvariant::Type)]
-pub struct Playlist {
-    musics: Vec<Music>,
-    sort: Sort,
-    repeat: Repeat,
-    playing_index: u32,
-}
-
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, zbus::zvariant::Type)]
-pub struct OuterPlaylist {
-    pub musics: Vec<OuterMusic>,
-    pub sort: Sort,
-    pub repeat: Repeat,
-    pub playing_index: u32,
-}
-
-#[derive(
-    PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize, zbus::zvariant::Type, Default,
-)]
-pub struct OuterMusic {
-    pub title: String,
-    pub length: Duration,
-    pub path: FilePath<'static>,
-    pub artist: String,
-    pub genre: String,
-}
+use crate::types::{OuterPlaylist, PlaylistOpperation};
 
 // NOTE: the return status of most functions is not currently documented, tho
 // usually they represent the success of the opperaiton/call.
@@ -214,6 +56,8 @@ pub trait Server {
     fn get_previous_music(&self) -> Result<OuterMusic>;
     /// Gets the index of the currently playing music
     fn get_playing_index(&self) -> Result<u32>;
+    // /// Gets the index of the currently playing music
+    // fn get_playlist_name(&self) -> Result<u32>;
     /// Gets the played duration for the currently playing music
     fn played_duration(&self) -> Result<f32>;
     /// Plays previous music on the playlist music list
@@ -228,6 +72,9 @@ pub trait Server {
     fn repeat(&self, repeat: Repeat) -> Result<RunStatus>;
     /// Returns current playlist
     fn playlist(&self) -> Result<OuterPlaylist>;
+    fn get_playlists(&self) -> Result<HashMap<String, Playlist>>;
+    fn get_playlists_names(&self) -> Result<Vec<String>>;
+    fn use_playlist(&self, title: String) -> Result<()>;
     /// Returns the lyrics of the current music
     fn lyrics(&self) -> Result<Lyrics>;
     /// Returns metadata of the current music
@@ -263,6 +110,18 @@ pub trait Server {
     fn seek(&self, duration: f64) -> Result<RunStatus>;
     /// changes the volume of the player (valueb between 0 and 1)
     fn volume(&self, amount: f32) -> Result<RunStatus>;
+    async fn rename_playlist(&self, old: &str, new: &str) -> Result<RunStatus>;
+    async fn remove_playlist(&self, new: &str) -> Result<RunStatus>;
+    async fn reload_config(&self) -> Result<()>;
+    async fn create_playlist(&self, id: String) -> Result<()>;
+    async fn save_to_playlist(
+        &self,
+        index: usize,
+        source: String,
+        destination: String,
+    ) -> Result<RunStatus>;
+    /// Gets current playlist name
+    async fn get_playlist_name(&self) -> Result<String>;
     /// Gets player volume (between 0 and 1)
     fn get_volume(&self) -> Result<f32>;
     /// Gets the currently playing [Music]
@@ -289,6 +148,25 @@ pub trait Server {
     /// Signal fires when the repeat status changes
     #[zbus(signal)]
     async fn repeat_changed(&self, sort: Repeat) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    async fn playlists_updated(
+        &self,
+        opperatioin: PlaylistOpperation,
+        id: &str,
+    ) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_loaded(&self, id: &str) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_deleted(&mut self, id: &str) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    #[allow(unused)]
+    async fn playlist_created(&mut self, id: &str) -> zbus::Result<()>;
 }
 
 pub fn init_panic_hook() {

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,10 +1,11 @@
 #![allow(dead_code)]
 use futures::executor::block_on;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use crate::{
-    EndedStream, Metadata, MusicPlayedStream, OuterMusic, PausedStream, PlayingStatus, Repeat,
-    ResumedStream, ServerProxy, Sort, SortedStream, VolumeChangedStream,
+    EndedStream, Metadata, MusicPlayedStream, OuterMusic, PausedStream, PlayingStatus, Playlist,
+    PlaylistCreatedStream, PlaylistDeletedStream, PlaylistLoadedStream, PlaylistsUpdatedStream,
+    Repeat, ResumedStream, ServerProxy, Sort, SortedStream, VolumeChangedStream,
 };
 
 #[derive(Debug, PartialEq, Eq, Default, Clone)]
@@ -31,6 +32,8 @@ pub struct Batch {
     pub music_duration: Duration,
     /// currently playing music
     pub playing_music: OuterMusic,
+    /// Names of given playlists
+    pub playlists_names: Vec<String>,
     /// status <Playing|Pausing|Stopping>
     pub status: PlayingStatus,
     /// playing volume
@@ -52,6 +55,10 @@ pub struct Streams {
     pub music_played_stream: Option<MusicPlayedStream>,
     pub volume_changed_stream: Option<VolumeChangedStream>,
     pub sorted_stream: Option<SortedStream>,
+    pub playlist_updated: Option<PlaylistsUpdatedStream>,
+    pub playlist_loaded: Option<PlaylistLoadedStream>,
+    pub playlist_deleted: Option<PlaylistDeletedStream>,
+    pub playlist_created: Option<PlaylistCreatedStream>,
 }
 
 impl Default for Streams {
@@ -63,6 +70,10 @@ impl Default for Streams {
             music_played_stream: None,
             volume_changed_stream: None,
             sorted_stream: None,
+            playlist_updated: None,
+            playlist_loaded: None,
+            playlist_deleted: None,
+            playlist_created: None,
         }
     }
 }
@@ -155,7 +166,7 @@ impl<'a> State<'a> {
         self.batch.metadata = self.proxy.metadata().await.unwrap_or_default()
     }
 
-    pub fn new(proxy: ServerProxy<'_>) -> State {
+    pub fn new(proxy: ServerProxy<'_>) -> State<'_> {
         State {
             proxy,
             batch: Batch::default(),
@@ -208,6 +219,10 @@ impl<'a> State<'a> {
         self.batch.metadata.to_owned()
     }
 
+    pub fn playlist_names(&self) -> Vec<String> {
+        self.batch.playlists_names.to_owned()
+    }
+
     /// plays the music from the path
     pub fn play(&self) {
         block_on(self.proxy.play()).unwrap();
@@ -228,12 +243,12 @@ impl<'a> State<'a> {
     }
 
     /// Resumes the player
-    pub fn resume(&self) {
+    pub fn resume_stream(&self) {
         block_on(self.proxy.resume()).unwrap();
     }
 
     /// Pauses the player
-    pub fn pause(&self) {
+    pub fn pause_stream(&self) {
         block_on(self.proxy.pause()).unwrap();
     }
 
@@ -286,9 +301,17 @@ impl<'a> State<'a> {
 
     /// Fetch currently playing [Music] [Metadata] e.g. Lyrics, Cover, etc.
     pub async fn fetch_playlist_data(&mut self) {
-        // ----------------------------------------------
-        self.batch.metadata = self.proxy.metadata().await.unwrap_or_default();
-        // ----------------------------------------------
+        self.fetch_music_metadata().await;
+        self.fetch_duration_sync().await;
+        self.fetch_playing_music().await;
+        self.fetch_playlists_names().await;
+    }
+
+    pub async fn fetch_playing_music(&mut self) {
+        self.batch.playing_music = self.proxy.playing().await.unwrap_or_default();
+    }
+
+    pub async fn fetch_duration_sync(&mut self) {
         let timer = self.proxy.timer().await.unwrap_or_default();
         let played = timer.0;
         let full = timer.1;
@@ -296,9 +319,14 @@ impl<'a> State<'a> {
             Duration::from_secs_f32(played),
             Duration::from_secs_f32(full),
         );
-        // ----------------------------------------------
-        self.batch.playing_music = self.proxy.playing().await.unwrap_or_default();
-        // ----------------------------------------------
+    }
+
+    pub async fn fetch_playlists_names(&mut self) {
+        self.batch.playlists_names = self.proxy.get_playlists_names().await.unwrap_or_default();
+    }
+
+    pub async fn fetch_music_metadata(&mut self) {
+        self.batch.metadata = self.proxy.metadata().await.unwrap_or_default();
     }
 
     pub async fn toggle_play(&self) {
@@ -317,12 +345,21 @@ impl<'a> State<'a> {
         block_on(async { self.proxy.get_repeat().await.unwrap_or_default() })
     }
 
-    pub(crate) fn get_order(&self) -> crate::Sort {
+    pub fn get_order(&self) -> crate::Sort {
         block_on(async { self.proxy.get_sort().await.unwrap_or_default() })
     }
 
     pub(crate) fn get_volume(&self) -> f32 {
         block_on(async { self.proxy.get_volume().await.unwrap_or_default() })
+    }
+
+    pub fn get_playlists(&self) -> HashMap<String, Playlist> {
+        block_on(async { self.proxy.get_playlists().await.unwrap_or_default() })
+    }
+
+    /// Gets playlist names directly from the dbus proxy
+    pub fn get_playlists_names(&self) -> Vec<String> {
+        block_on(async { self.proxy.get_playlists_names().await.unwrap_or_default() })
     }
 
     pub(crate) async fn increase_volume(&self) {

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,144 @@
+use ratatui::style::Color;
+
+#[derive(Default)]
+pub struct UIStyle {
+    pub list_style: ListStyle,
+    pub action_style: ActionStyle,
+    pub seeker_style: SeekerStyle,
+    pub volume_style: VolumeStyle,
+    pub lyrics_style: LyricsStyle,
+    pub playlists_style: PlaylistsStyle,
+}
+
+pub struct ListStyle {
+    pub hilight_color: Color,
+    pub active_region_color: Color,
+    pub active_search_region_color: Color,
+    pub active_after_search_region_color: Color,
+    pub active_command_region_color: Color,
+    pub passive_region_color: Color,
+    pub selector: String,
+    pub playing_selector: String,
+    pub playing_region_color: Color,
+}
+
+pub struct SeekerStyle {
+    pub active_region_color: Color,
+    pub passive_region_color: Color,
+    pub fg_seeker_color: Color,
+    pub bg_seeker_color: Color,
+}
+
+pub struct VolumeStyle {
+    pub active_region_color: Color,
+    pub passive_region_color: Color,
+    pub fg_volume_color: Color,
+    pub bg_volume_color: Color,
+}
+
+pub struct PlaylistsStyle {
+    pub active_region_color: Color,
+    pub passive_region_color: Color,
+    pub selector: String,
+}
+
+pub struct LyricsStyle {
+    pub active_region_color: Color,
+    pub passive_region_color: Color,
+    pub selector: String,
+}
+
+pub struct ActionStyle {
+    pub hilight_color: Color,
+    pub active_region_color: Color,
+    pub passive_region_color: Color,
+}
+
+impl Default for ListStyle {
+    fn default() -> Self {
+        ListStyle {
+            hilight_color: Color::default(),
+            playing_region_color: Color::Gray,
+            active_region_color: Color::Magenta,
+            active_command_region_color: Color::Cyan,
+            active_after_search_region_color: Color::Cyan,
+            active_search_region_color: Color::DarkGray,
+            passive_region_color: Color::default(),
+            selector: String::from(">>"),
+            playing_selector: String::from("*"),
+        }
+    }
+}
+
+impl UIStyle {
+    #[allow(dead_code)]
+    pub fn new(
+        list_style: ListStyle,
+        action_style: ActionStyle,
+        seeker_style: SeekerStyle,
+        volume_style: VolumeStyle,
+        lyrics_style: LyricsStyle,
+        playlists_style: PlaylistsStyle,
+    ) -> Self {
+        UIStyle {
+            list_style,
+            action_style,
+            seeker_style,
+            volume_style,
+            lyrics_style,
+            playlists_style,
+        }
+    }
+}
+
+impl Default for SeekerStyle {
+    fn default() -> Self {
+        SeekerStyle {
+            active_region_color: Color::Magenta,
+            passive_region_color: Color::default(),
+            fg_seeker_color: Color::Gray,
+            bg_seeker_color: Color::Black,
+        }
+    }
+}
+
+impl Default for VolumeStyle {
+    fn default() -> Self {
+        VolumeStyle {
+            active_region_color: Color::Magenta,
+            passive_region_color: Color::default(),
+            fg_volume_color: Color::Gray,
+            bg_volume_color: Color::Black,
+        }
+    }
+}
+
+impl Default for ActionStyle {
+    fn default() -> Self {
+        ActionStyle {
+            hilight_color: Color::Yellow,
+            active_region_color: Color::Magenta,
+            passive_region_color: Color::default(),
+        }
+    }
+}
+
+impl Default for LyricsStyle {
+    fn default() -> Self {
+        LyricsStyle {
+            active_region_color: Color::Magenta,
+            passive_region_color: Color::default(),
+            selector: String::from(">>"),
+        }
+    }
+}
+
+impl Default for PlaylistsStyle {
+    fn default() -> Self {
+        Self {
+            active_region_color: Color::Magenta,
+            passive_region_color: Color::default(),
+            selector: String::from(">>"),
+        }
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,214 @@
+use std::time::Duration;
+
+use ratatui::text::Span;
+use zbus::zvariant::FilePath;
+
+#[derive(serde::Deserialize, serde::Serialize, zbus::zvariant::Type, Debug, Default, Clone)]
+pub struct Picture {
+    pub data: Vec<u8>,
+    pub typ: String,
+}
+
+#[derive(
+    PartialEq, Eq, Debug, Clone, zbus::zvariant::Type, serde::Deserialize, serde::Serialize,
+)]
+pub struct Lyrics {
+    pub time_is_correct: bool,
+    pub lines: Vec<Line>,
+}
+
+impl Default for Lyrics {
+    fn default() -> Self {
+        Self {
+            time_is_correct: false,
+            lines: vec![],
+        }
+    }
+}
+
+#[derive(
+    PartialEq, Eq, Debug, Clone, zbus::zvariant::Type, serde::Serialize, serde::Deserialize,
+)]
+pub struct Line {
+    pub content: String,
+    pub timestamp: Duration,
+}
+
+impl Default for Line {
+    fn default() -> Self {
+        Line {
+            content: String::new(),
+            timestamp: Duration::ZERO,
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize, zbus::zvariant::Type, Debug, Default, Clone)]
+pub struct Metadata {
+    pub title: String,
+    pub artis: String,
+    pub genre: String,
+    pub cover: Picture,
+    pub lyrics: Lyrics,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, Default, zbus::zvariant::Type)]
+pub enum PlayingStatus {
+    /// Pausing state
+    Playing,
+    /// Playing state
+    Pausing,
+    #[default]
+    /// Stopping state
+    Stopped,
+}
+
+#[derive(serde::Deserialize, serde::Serialize, Clone, Debug, zbus::zvariant::Type)]
+pub struct PlayerStatus {
+    pub status: PlayingStatus,
+    pub music: OuterMusic,
+    /// between 0 and 1
+    pub volume: f32,
+    pub index: u32,
+}
+
+#[derive(
+    PartialEq, Eq, Debug, Clone, serde::Serialize, serde::Deserialize, zbus::zvariant::Type, Default,
+)]
+pub struct OuterMusic {
+    pub title: String,
+    pub length: Duration,
+    pub path: FilePath<'static>,
+    pub artist: String,
+    pub genre: String,
+}
+
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    zbus::zvariant::Type,
+    Eq,
+    PartialEq,
+)]
+pub enum Sort {
+    #[default]
+    /// Sort  by music title in ascending order
+    ByTitleAscending,
+    /// Sort by music title in descending order
+    ByTitleDescending,
+    /// Sort by music length in ascending order
+    ByDurationAscending,
+    /// Sort by music length in descending order
+    ByDurationDescending,
+    /// Sort by music artist name in ascending order
+    ArtistAscending,
+    /// Sort by music artist name in descending order
+    ArtistDescending,
+    // Sort at random
+    Shuffle,
+}
+
+impl Sort {
+    pub fn as_span(&self) -> Span<'_> {
+        match self {
+            Sort::ByTitleAscending => Span::from("TitleAscending"),
+            Sort::ByTitleDescending => Span::from("TitleDescending"),
+            Sort::ByDurationAscending => Span::from("DurationAscending"),
+            Sort::ByDurationDescending => Span::from("DurationDescending"),
+            Sort::ArtistAscending => Span::from("ArtistAscending"),
+            Sort::ArtistDescending => Span::from("ArtistDescending"),
+            Sort::Shuffle => Span::from("Shuffle"),
+        }
+    }
+}
+
+#[derive(
+    serde::Serialize,
+    serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Default,
+    zbus::zvariant::Type,
+    Eq,
+    PartialEq,
+)]
+pub enum Repeat {
+    /// repeat the currently playing music
+    SameMusic,
+    #[default]
+    /// cycle through all the playlist
+    AllMusics,
+    /// stop after the currently playing music
+    Dont,
+}
+
+impl Repeat {
+    pub fn as_span(&self) -> Span<'_> {
+        match self {
+            Repeat::SameMusic => Span::from("RepeatMusic"),
+            Repeat::AllMusics => Span::from("RepeatList"),
+            Repeat::Dont => Span::from("NoRepeat"),
+        }
+    }
+}
+
+#[derive(
+    PartialEq,
+    Eq,
+    Debug,
+    Ord,
+    PartialOrd,
+    Clone,
+    serde::Serialize,
+    serde::Deserialize,
+    zbus::zvariant::Type,
+)]
+pub struct Music {
+    pub title: String,
+    pub length: Duration,
+    pub path: FilePath<'static>,
+    pub artist: String,
+    pub genre: String,
+    pub index: usize,
+}
+
+impl Default for Music {
+    fn default() -> Self {
+        Self {
+            title: String::new(),
+            length: Duration::ZERO,
+            path: FilePath::default(),
+            artist: String::new(),
+            genre: String::new(),
+            index: 0,
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, zbus::zvariant::Type)]
+pub struct Playlist {
+    musics: Vec<Music>,
+    sort: Sort,
+    repeat: Repeat,
+    playing_index: u32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default, zbus::zvariant::Type)]
+pub struct OuterPlaylist {
+    pub musics: Vec<OuterMusic>,
+    pub sort: Sort,
+    pub repeat: Repeat,
+    pub playing_index: u32,
+    pub name: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, zbus::zvariant::Type)]
+pub enum PlaylistOpperation {
+    AddedMusic,
+    DeletedMusic,
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,16 @@
+// TODO: rename actions to pannel
+// TODO: add actions box for searching and commands e.g:
+// TODO: make a keybind to create a playlist
+// TODO: make a keybind to add a music to a playlist
+// TODO: make search golobal command, when canceling, you go back to original region when search is
+// done (this also allows for the after search effect, you temporary get transported to the list
+// region)
+// TODO: implement :delete_from_this_playlist and :delete_from_playlist [playlist_name] [name or index of music]
+// TODO: implement :add_from_this_playlist [destination] and :add_from_playlist [source] [name or
+// index] [destination]
 use crate::parser::Scripts;
+use crate::style::UIStyle;
+use crate::types::Music;
 use crate::{Repeat, Sort};
 use crossterm::event::Event as CrosstermEvent;
 use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -9,12 +21,13 @@ use mlua::{UserData, UserDataMethods};
 use ratatui::{prelude::*, style::Stylize, widgets::*};
 use serde::{Deserialize, Serialize};
 use std::io;
+use std::str::FromStr;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 use tokio::time::Interval;
 use tui_input::{Input, InputRequest, StateChanged};
-use zbus::zvariant::FilePath;
 
+use crate::allowed_commands::{CommandContext, CommandName};
 use crate::states::State;
 use crate::utils::{log, FPSController};
 use crate::{fuzzy_search, Config, Lyrics, PlayingStatus, ServerProxy};
@@ -22,16 +35,20 @@ use crate::{fuzzy_search, Config, Lyrics, PlayingStatus, ServerProxy};
 pub struct ViewConfiguration {
     lyrics: bool,
     search: bool,
+    command: bool,
+    playlists: bool,
 }
 
 pub struct ViewGeometry {
     frame: Rect,
     list: Rect,
     lyrics: Option<Rect>,
+    playlists: Option<Rect>,
     actions: Rect,
     volume: Rect,
     slider: Rect,
     search: Option<Rect>,
+    command: Option<Rect>,
     configuration: ViewConfiguration,
 }
 
@@ -40,7 +57,9 @@ impl ViewGeometry {
         frame: Rect,
         list: Rect,
         lyrics: Option<Rect>,
+        playlists: Option<Rect>,
         search: Option<Rect>,
+        command: Option<Rect>,
         actions: Rect,
         slider: Rect,
         volume: Rect,
@@ -50,10 +69,12 @@ impl ViewGeometry {
             frame,
             list,
             lyrics,
+            playlists,
             actions,
             volume,
             slider,
             search,
+            command,
             configuration,
         }
     }
@@ -64,12 +85,16 @@ impl ViewGeometry {
             frame,
             None,
             None,
+            None,
+            None,
             frame,
             frame,
             frame,
             ViewConfiguration {
                 search: false,
                 lyrics: false,
+                playlists: false,
+                command: false,
             },
         );
         init.calculate_gemoetry();
@@ -79,10 +104,10 @@ impl ViewGeometry {
     fn calculate_list(&mut self) {
         let mut init = self.frame;
         init.height = init.height.saturating_sub(7);
-        if self.configuration.search {
+        if self.configuration.search || self.configuration.command {
             init.height = init.height.saturating_sub(3);
         }
-        if self.configuration.lyrics {
+        if self.configuration.lyrics || self.configuration.playlists {
             init.height /= 2;
             init.height = init.height.saturating_sub(1);
         }
@@ -104,6 +129,21 @@ impl ViewGeometry {
         }
     }
 
+    fn calculate_playlists(&mut self) {
+        if self.configuration.playlists {
+            let mut init = self.frame;
+            init.height = init.height.saturating_sub(4) / 2;
+            init.y = init.height.saturating_sub(2);
+            if self.configuration.search {
+                init.height = init.height.saturating_sub(1);
+                init.y = init.y + 1;
+            }
+            self.playlists = Some(init);
+        } else {
+            self.playlists = None;
+        }
+    }
+
     fn calculate_search(&mut self) {
         if self.configuration.search {
             let mut init = self.frame;
@@ -119,11 +159,25 @@ impl ViewGeometry {
         }
     }
 
+    fn calculate_command(&mut self) {
+        if self.configuration.command {
+            let mut init = self.frame;
+            init.y = init.height.saturating_sub(10);
+            if self.configuration.lyrics {
+                init.y = init.y / 2;
+                init.y = init.y.saturating_sub(1);
+            }
+            init.height = 3;
+            self.command = Some(init);
+        } else {
+            self.command = None;
+        }
+    }
+
     fn calculate_actions(&mut self) {
         let mut area = self.frame;
         if area.height > 7 {
-            // - seeker hight - action height
-            area.y = area.height - 3 - 4;
+            area.y = area.height.saturating_sub(3).saturating_sub(4);
             area.height = 3;
         }
         self.actions = area;
@@ -146,11 +200,12 @@ impl ViewGeometry {
         self.volume = area;
     }
 
-    // TODO: migrate to using saturating_sub instead of if checking
     pub fn calculate_gemoetry(&mut self) {
         self.calculate_list();
         self.calculate_lyrics();
+        self.calculate_playlists();
         self.calculate_search();
+        self.calculate_command();
         self.calculate_actions();
         self.calculate_slider();
         self.calculate_volume();
@@ -166,6 +221,10 @@ impl ViewGeometry {
 
     pub fn lyrics_geo(&self) -> Option<Rect> {
         self.lyrics
+    }
+
+    pub fn playlists_geo(&self) -> Option<Rect> {
+        self.playlists
     }
 
     pub fn actions_geo(&self) -> Rect {
@@ -184,21 +243,62 @@ impl ViewGeometry {
         self.search
     }
 
+    pub fn command_geo(&self) -> Option<Rect> {
+        self.command
+    }
+
     pub fn enable_search(&mut self) {
         self.configuration.search = true;
+    }
+
+    pub fn enable_command(&mut self) {
+        self.configuration.command = true;
     }
 
     pub fn disable_search(&mut self) {
         self.configuration.search = false;
     }
 
+    pub fn disable_command(&mut self) {
+        self.configuration.command = false;
+    }
+
+    #[allow(unused)]
+    pub fn disable_toggled(&mut self) {
+        self.configuration.lyrics = false;
+        self.configuration.playlists = false;
+    }
+
     pub fn toggle_lyrics(&mut self) {
         self.configuration.lyrics = !self.configuration.lyrics;
+    }
+
+    pub fn disable_lyrics(&mut self) {
+        self.configuration.lyrics = false;
+    }
+
+    #[allow(unused)]
+    pub fn enable_lyrics(&mut self) {
+        self.configuration.lyrics = true;
+    }
+
+    pub fn toggle_playlists(&mut self) {
+        self.configuration.playlists = !self.configuration.playlists;
+    }
+
+    pub fn disable_playlists(&mut self) {
+        self.configuration.playlists = false;
+    }
+
+    #[allow(unused)]
+    pub fn enable_playlists(&mut self) {
+        self.configuration.playlists = true;
     }
 }
 
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub enum ListMode {
+    Command,
     Search,
     #[default]
     Select,
@@ -230,6 +330,8 @@ pub struct UI<'a> {
     pub mode: ListMode,
     /// search buffer, used to search through the musics list
     search_bufr: Input,
+    /// command buffer, used to input commands
+    command_bufr: Input,
     /// helps reading a combination of keys like `gg`
     pub anticipation_mode: AncitipationMode,
     /// what to repeat <ThisMusic, AllMusics, None>
@@ -240,10 +342,17 @@ pub struct UI<'a> {
     pub state: State<'a>,
     // TODO: make this private
     pub fps_controller: FPSController,
+    /// Displayed lyrics
     displayed_lyrics: DisplayedLyrics,
+    /// Displayed Playlists
+    displayed_playlists: DisplayedPlaylists,
+    /// Views/widgets geometry
     pub geometry: ViewGeometry,
+    /// Used for event checking
     pub internal_clock: Interval,
+    /// Lua scripts
     pub scripts: Option<Functions>,
+    /// Lua interpreter
     pub lua: Lua,
 }
 
@@ -285,6 +394,9 @@ pub enum Region {
     Seeker,
     Volume,
     Lyrics,
+    Playlist,
+    Search,
+    Command,
 }
 
 impl Default for Region {
@@ -307,14 +419,15 @@ impl ListMode {
                         return;
                     }
                     KeyCode::Esc => {
-                        ui.mode = ListMode::AfterSearch;
+                        ui.change_list_mode(ListMode::AfterSearch);
+                        ui.select_region(Region::List);
                         return;
                     }
                     _ => {}
                 },
                 _ => {}
             }
-            ui.register_querry(key.to_owned()).await;
+            ui.register_search_query(key.to_owned()).await;
         }
     }
 
@@ -361,7 +474,14 @@ impl ListMode {
                             KeyCode::Char(c) => match c {
                                 'j' => ui.list_down(),
                                 'k' => ui.list_up(),
-                                '/' => ui.change_list_mode(ListMode::Search),
+                                '/' => {
+                                    ui.select_region(Region::Search);
+                                    ui.change_list_mode(ListMode::Search)
+                                }
+                                ':' => {
+                                    ui.change_list_mode(ListMode::Command);
+                                    ui.select_region(Region::Command);
+                                }
                                 ' ' => ui.play_selected_music().await,
                                 's' => ui.goto_playing(),
                                 'g' => ui.anticipate('g'),
@@ -402,6 +522,33 @@ impl ListMode {
                 },
                 _ => {}
             }
+        }
+        Ok(false)
+    }
+
+    async fn handle_command(ui: &mut UI<'_>, key: &KeyEvent) -> std::io::Result<bool> {
+        if key.kind == event::KeyEventKind::Press {
+            ui.run_list_script(key, ListMode::Search);
+            match key.modifiers {
+                KeyModifiers::NONE => match key.code {
+                    KeyCode::Enter => {
+                        if ui.run_command().await? {
+                            return Ok(true);
+                        }
+                        ui.change_list_mode(ListMode::Select);
+                        ui.select_region(Region::List);
+                        return Ok(false);
+                    }
+                    KeyCode::Esc => {
+                        ui.change_list_mode(ListMode::Select);
+                        ui.select_region(Region::List);
+                        return Ok(false);
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+            ui.register_command_query(key.to_owned()).await;
         }
         Ok(false)
     }
@@ -452,6 +599,30 @@ impl Region {
                     return Ok(true);
                 }
             }
+            Region::Search => {
+                if Region::handle_search(ui, &key)
+                    .await
+                    .is_ok_and(|should_quit| should_quit == true)
+                {
+                    return Ok(true);
+                }
+            }
+            Region::Command => {
+                if Region::handle_command(ui, &key)
+                    .await
+                    .is_ok_and(|should_quit| should_quit == true)
+                {
+                    return Ok(true);
+                }
+            }
+            Region::Playlist => {
+                if Region::handle_playlist(ui, &key)
+                    .await
+                    .is_ok_and(|should_quit| should_quit == true)
+                {
+                    return Ok(true);
+                }
+            }
         }
         return Ok(false);
     }
@@ -462,7 +633,7 @@ impl Region {
             match key.modifiers {
                 KeyModifiers::NONE => match key.code {
                     KeyCode::Char(c) => match ui.mode {
-                        ListMode::Search => {}
+                        ListMode::Search | ListMode::Command => {}
                         _ => match c {
                             'm' => ui.toggle_mute().await,
                             'p' => ui.toggle_play().await,
@@ -479,21 +650,27 @@ impl Region {
                                 Region::List => {
                                     if ui.displayed_lyrics.displayable {
                                         ui.select_lyrics_region()
+                                    } else if ui.displayed_playlists.displayable {
+                                        ui.select_playlist_region()
                                     } else {
                                         ui.select_action_region()
                                     }
                                 }
-                                Region::Lyrics => ui.select_action_region(),
+                                Region::Lyrics | Region::Playlist => ui.select_action_region(),
                                 Region::Action => ui.select_bar_region(),
                                 Region::Seeker => ui.select_list_region(),
                                 Region::Volume => ui.select_list_region(),
+                                Region::Search | Region::Command => {}
                             },
                             'k' => match ui.region {
+                                Region::Search | Region::Command => {}
                                 Region::List => ui.select_volume_region(),
-                                Region::Lyrics => ui.select_list_region(),
+                                Region::Lyrics | Region::Playlist => ui.select_list_region(),
                                 Region::Action => {
                                     if ui.displayed_lyrics.displayable {
                                         ui.select_lyrics_region()
+                                    } else if ui.displayed_playlists.displayable {
+                                        ui.select_playlist_region()
                                     } else {
                                         ui.select_list_region()
                                     }
@@ -515,6 +692,7 @@ impl Region {
                 KeyModifiers::CONTROL => match key.code {
                     KeyCode::Char(c) => match c {
                         'l' => ui.toggle_lyrics(),
+                        'p' => ui.toggle_playlists(),
                         _ => {}
                     },
                     _ => {}
@@ -534,9 +712,6 @@ impl Region {
 
     pub async fn handle_list<'a>(ui: &mut UI<'a>, key: &KeyEvent) -> std::io::Result<bool> {
         match ui.mode {
-            ListMode::Search => {
-                ListMode::handle_search(ui, key).await;
-            }
             ListMode::AfterSearch => {
                 if ListMode::handle_after_search(ui, key)
                     .await
@@ -553,6 +728,7 @@ impl Region {
                     return Ok(true);
                 }
             }
+            _ => {}
         }
         Ok(false)
     }
@@ -688,129 +864,43 @@ impl Region {
         }
         Ok(false)
     }
-}
 
-#[derive(Default)]
-pub struct UIStyle {
-    list_style: ListStyle,
-    action_style: ActionStyle,
-    seeker_style: SeekerStyle,
-    volume_style: VolumeStyle,
-    lyrics_style: LyricsStyle,
-}
-
-pub struct ListStyle {
-    hilight_color: Color,
-    active_region_color: Color,
-    active_search_region_color: Color,
-    active_after_search_region_color: Color,
-    passive_region_color: Color,
-    selector: String,
-    playing_selector: String,
-    playing_region_color: Color,
-}
-
-pub struct SeekerStyle {
-    active_region_color: Color,
-    passive_region_color: Color,
-    fg_seeker_color: Color,
-    bg_seeker_color: Color,
-}
-
-pub struct VolumeStyle {
-    active_region_color: Color,
-    passive_region_color: Color,
-    fg_volume_color: Color,
-    bg_volume_color: Color,
-}
-
-pub struct LyricsStyle {
-    active_region_color: Color,
-    passive_region_color: Color,
-    selector: String,
-}
-
-pub struct ActionStyle {
-    hilight_color: Color,
-    active_region_color: Color,
-    passive_region_color: Color,
-}
-
-impl Default for ListStyle {
-    fn default() -> Self {
-        ListStyle {
-            hilight_color: Color::default(),
-            playing_region_color: Color::Gray,
-            active_region_color: Color::Magenta,
-            active_after_search_region_color: Color::Cyan,
-            active_search_region_color: Color::DarkGray,
-            passive_region_color: Color::default(),
-            selector: String::from(">>"),
-            playing_selector: String::from("*"),
+    async fn handle_playlist(ui: &mut UI<'_>, key: &KeyEvent) -> std::io::Result<bool> {
+        if key.kind == event::KeyEventKind::Press {
+            match key.modifiers {
+                KeyModifiers::NONE => match key.code {
+                    KeyCode::Char(c) => match c {
+                        'q' => return ui.quit(),
+                        'j' => ui.select_next_playlist_name(),
+                        'k' => ui.select_previous_playlist_name(),
+                        _ => {}
+                    },
+                    KeyCode::Enter => {
+                        ui.switch_to_selected_playlist().await;
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
         }
+        return Ok(false);
     }
-}
 
-impl UIStyle {
-    #[allow(dead_code)]
-    pub fn new(
-        list_style: ListStyle,
-        action_style: ActionStyle,
-        seeker_style: SeekerStyle,
-        volume_style: VolumeStyle,
-        lyrics_style: LyricsStyle,
-    ) -> Self {
-        UIStyle {
-            list_style,
-            action_style,
-            seeker_style,
-            volume_style,
-            lyrics_style,
+    async fn handle_search(ui: &mut UI<'_>, key: &KeyEvent) -> std::io::Result<bool> {
+        match ui.mode {
+            ListMode::Search => {
+                ListMode::handle_search(ui, key).await;
+            }
+            _ => {}
         }
+        // Never quit on search mode
+        Ok(false)
     }
-}
 
-impl Default for SeekerStyle {
-    fn default() -> Self {
-        SeekerStyle {
-            active_region_color: Color::Magenta,
-            passive_region_color: Color::default(),
-            fg_seeker_color: Color::Gray,
-            bg_seeker_color: Color::Black,
-        }
-    }
-}
-
-impl Default for VolumeStyle {
-    fn default() -> Self {
-        VolumeStyle {
-            active_region_color: Color::Magenta,
-            passive_region_color: Color::default(),
-            fg_volume_color: Color::Gray,
-            bg_volume_color: Color::Black,
-        }
-    }
-}
-
-impl Default for ActionStyle {
-    fn default() -> Self {
-        ActionStyle {
-            hilight_color: Color::Yellow,
-            active_region_color: Color::Magenta,
-            passive_region_color: Color::default(),
-        }
-    }
-}
-
-impl Default for LyricsStyle {
-    fn default() -> Self {
-        LyricsStyle {
-            active_region_color: Color::Magenta,
-            passive_region_color: Color::default(),
-            selector: String::from(">>"),
-            // hilight_color: Color::default(),
-            // playing_region_color: Color::Gray,
-            // playing_selector: String::from("*"),
+    async fn handle_command(ui: &mut UI<'_>, key: &KeyEvent) -> std::io::Result<bool> {
+        match ui.mode {
+            ListMode::Command => ListMode::handle_command(ui, key).await,
+            _ => Ok(false),
         }
     }
 }
@@ -958,11 +1048,13 @@ impl<'a> UI<'a> {
             state: State::new(proxy),
             mode: ListMode::default(),
             search_bufr: Input::default(),
+            command_bufr: Input::default(),
             anticipation_mode: AncitipationMode::default(),
             displayed_repeat: Repeat::default(),
             displayed_sort: Sort::default(),
-            fps_controller: FPSController::default(),
             displayed_lyrics: DisplayedLyrics::default(),
+            displayed_playlists: DisplayedPlaylists::default(),
+            fps_controller: FPSController::default(),
             geometry: ViewGeometry::default(Rect::default()),
             internal_clock: tokio::time::interval(Duration::from_secs(1)),
             lua,
@@ -974,6 +1066,7 @@ impl<'a> UI<'a> {
         let paused_stream = self.state.dbus_streams.paused_stream.as_mut().unwrap();
         let resumed_stream = self.state.dbus_streams.resumed_stream.as_mut().unwrap();
         let stopped_stream = self.state.dbus_streams.stopped_stream.as_mut().unwrap();
+        let playlist_updated_stream = self.state.dbus_streams.playlist_updated.as_mut().unwrap();
         let volume_stream = self
             .state
             .dbus_streams
@@ -986,7 +1079,45 @@ impl<'a> UI<'a> {
             .music_played_stream
             .as_mut()
             .unwrap();
+        let playlist_created_stream = self.state.dbus_streams.playlist_created.as_mut().unwrap();
+        let playlist_deleted_stream = self.state.dbus_streams.playlist_deleted.as_mut().unwrap();
+        let playlist_loaded_stream = self.state.dbus_streams.playlist_loaded.as_mut().unwrap();
         let sorted_stream = self.state.dbus_streams.sorted_stream.as_mut().unwrap();
+
+        match playlist_updated_stream.poll_next_unpin(&mut ctx) {
+            Poll::Ready(_) => {
+                let playlist = self.state.proxy.playlist().await.unwrap_or_default();
+                self.music_list.unfiltered_music_list.clear();
+                for (index, music) in playlist.musics.iter().enumerate() {
+                    let music = music.to_owned();
+                    self.music_list.unfiltered_music_list.push(Music {
+                        path: music.path,
+                        title: music.title,
+                        length: music.length,
+                        artist: music.artist,
+                        genre: music.genre,
+                        index,
+                    });
+                }
+                self.music_list.musics = self.music_list.unfiltered_music_list.clone();
+                self.music_list.playing_index = playlist.playing_index as usize;
+                self.state.batch.metadata = self.state.proxy.metadata().await.unwrap_or_default();
+
+                let timer = self.state.proxy.timer().await.unwrap_or_default();
+                let played = timer.0;
+                let full = timer.1;
+                (
+                    self.state.batch.played_duration,
+                    self.state.batch.music_duration,
+                ) = (
+                    Duration::from_secs_f32(played),
+                    Duration::from_secs_f32(full),
+                );
+                self.state.batch.playing_music =
+                    self.state.proxy.playing().await.unwrap_or_default();
+            }
+            _ => {}
+        }
 
         match paused_stream.poll_next_unpin(&mut ctx) {
             Poll::Ready(_) => {
@@ -1025,6 +1156,69 @@ impl<'a> UI<'a> {
             Poll::Ready(v) => {
                 let volume = v.unwrap().args().unwrap().amount.max(0.0).min(1.0);
                 self.state.batch.volume = volume;
+            }
+            _ => {}
+        }
+
+        match playlist_created_stream.poll_next_unpin(&mut ctx) {
+            Poll::Ready(v) => {
+                self.state
+                    .batch
+                    .playlists_names
+                    .push(v.unwrap().args().unwrap().id().to_string());
+            }
+            _ => {}
+        }
+
+        match playlist_deleted_stream.poll_next_unpin(&mut ctx) {
+            Poll::Ready(v) => {
+                let id = v.unwrap().args().unwrap().id().to_string();
+                if let Some(pos) = self
+                    .state
+                    .batch
+                    .playlists_names
+                    .iter()
+                    .position(|x| x.eq(&id))
+                {
+                    self.state.batch.playlists_names.remove(pos);
+                }
+            }
+            _ => {}
+        }
+
+        match playlist_loaded_stream.poll_next_unpin(&mut ctx) {
+            Poll::Ready(_) => {
+                self.state.batch.status = PlayingStatus::Stopped;
+
+                let playlist = self.state.proxy.playlist().await.unwrap_or_default();
+                self.music_list.unfiltered_music_list.clear();
+                for (index, music) in playlist.musics.iter().enumerate() {
+                    let music = music.to_owned();
+                    self.music_list.unfiltered_music_list.push(Music {
+                        path: music.path,
+                        title: music.title,
+                        length: music.length,
+                        artist: music.artist,
+                        genre: music.genre,
+                        index,
+                    });
+                }
+                self.music_list.musics = self.music_list.unfiltered_music_list.clone();
+                self.music_list.playing_index = playlist.playing_index as usize;
+                self.state.batch.metadata = self.state.proxy.metadata().await.unwrap_or_default();
+
+                let timer = self.state.proxy.timer().await.unwrap_or_default();
+                let played = timer.0;
+                let full = timer.1;
+                (
+                    self.state.batch.played_duration,
+                    self.state.batch.music_duration,
+                ) = (
+                    Duration::from_secs_f32(played),
+                    Duration::from_secs_f32(full),
+                );
+                self.state.batch.playing_music =
+                    self.state.proxy.playing().await.unwrap_or_default();
             }
             _ => {}
         }
@@ -1204,6 +1398,10 @@ impl<'a> UI<'a> {
 
         let block = match self.region {
             Region::List => match self.mode {
+                ListMode::Command => Block::default()
+                    .title("Musics")
+                    .borders(Borders::ALL)
+                    .fg(self.style.list_style.active_command_region_color),
                 ListMode::Search => Block::default()
                     .title("Musics")
                     .borders(Borders::ALL)
@@ -1235,20 +1433,6 @@ impl<'a> UI<'a> {
                 Row::new(vec!["Title", "artist", "genre", "duration"])
                     .style(Style::new().bold().italic()),
             );
-
-        match self.mode {
-            ListMode::Search | ListMode::AfterSearch => match self.geometry.search_geo() {
-                Some(geo) => {
-                    frame.render_widget(
-                        Paragraph::new(self.search_bufr.value())
-                            .block(Block::bordered().title("Querry")),
-                        geo,
-                    );
-                }
-                None => {}
-            },
-            ListMode::Select => {}
-        }
 
         frame.render_stateful_widget(table, self.geometry.list_geo(), &mut self.music_list.state);
     }
@@ -1291,6 +1475,10 @@ impl<'a> UI<'a> {
                     .title("Musics")
                     .borders(Borders::ALL)
                     .fg(self.style.list_style.active_region_color),
+                ListMode::Command => Block::default()
+                    .title("Musics")
+                    .borders(Borders::ALL)
+                    .fg(self.style.list_style.active_command_region_color),
             },
             _ => Block::default()
                 .title("Musics")
@@ -1311,6 +1499,16 @@ impl<'a> UI<'a> {
             );
 
         match self.mode {
+            ListMode::Command => match self.geometry.command_geo() {
+                Some(geo) => {
+                    frame.render_widget(
+                        Paragraph::new(self.command_bufr.value())
+                            .block(Block::bordered().title("Querry")),
+                        geo,
+                    );
+                }
+                None => {}
+            },
             ListMode::Search | ListMode::AfterSearch => match self.geometry.search_geo() {
                 Some(geo) => {
                     frame.render_widget(
@@ -1557,7 +1755,10 @@ impl<'a> UI<'a> {
     pub fn render(&mut self, frame: &mut Frame) {
         self.update_geometry(frame);
         self.render_list(frame);
+        self.render_search(frame);
         self.render_lyrics(frame);
+        self.render_playlists(frame);
+        self.render_commands(frame);
         self.render_actions(frame);
         self.render_volume(frame);
         self.render_seeker(frame);
@@ -1584,18 +1785,24 @@ impl<'a> UI<'a> {
         let quesize = self.music_list.musics.len();
         let selected_index = self.music_list.selected;
 
-        if selected_index == quesize - 1 {
+        if Some(selected_index) == quesize.checked_sub(1) {
             self.music_list.selected = 0;
         } else {
             self.music_list.selected = self.music_list.selected + 1;
         }
     }
 
-    /// Appends the char to the existing search querry and search it
-    pub async fn register_querry(&mut self, c: KeyEvent) {
+    /// Appends the char to the existing search buffer
+    pub async fn register_search_query(&mut self, c: KeyEvent) {
         self.search_bufr
             .handle_event(&crossterm::event::Event::Key(c));
         self.music_list.search(self.search_bufr.value().to_owned());
+    }
+
+    /// Appends the char to the existing command buffer
+    pub async fn register_command_query(&mut self, c: KeyEvent) {
+        self.command_bufr
+            .handle_event(&crossterm::event::Event::Key(c));
     }
 
     /// Resets the search querry to an empty string
@@ -1729,6 +1936,14 @@ impl<'a> UI<'a> {
             Some(self.state.proxy.receive_volume_changed().await.unwrap());
         self.state.dbus_streams.sorted_stream =
             Some(self.state.proxy.receive_sorted().await.unwrap());
+        self.state.dbus_streams.playlist_updated =
+            Some(self.state.proxy.receive_playlists_updated().await.unwrap());
+        self.state.dbus_streams.playlist_loaded =
+            Some(self.state.proxy.receive_playlist_loaded().await.unwrap());
+        self.state.dbus_streams.playlist_deleted =
+            Some(self.state.proxy.receive_playlist_deleted().await.unwrap());
+        self.state.dbus_streams.playlist_created =
+            Some(self.state.proxy.receive_playlist_created().await.unwrap());
         //----------------------------------------------------
         //TODO: make this something more readable
         self.displayed_repeat = self.state.get_repeat();
@@ -1754,39 +1969,19 @@ impl<'a> UI<'a> {
         // FIXME: prefor sorts?
         match self.action {
             PowerActions::Sort => match self.displayed_sort {
-                Sort::ByTitleAscending => {
-                    self.displayed_sort = Sort::Shuffle;
-                }
-                Sort::ByTitleDescending => {
-                    self.displayed_sort = Sort::ByTitleAscending;
-                }
-                Sort::ByDurationAscending => {
-                    self.displayed_sort = Sort::ByTitleDescending;
-                }
-                Sort::ByDurationDescending => {
-                    self.displayed_sort = Sort::ByDurationAscending;
-                }
-                Sort::ArtistAscending => {
-                    self.displayed_sort = Sort::ByDurationDescending;
-                }
-                Sort::ArtistDescending => {
-                    self.displayed_sort = Sort::ArtistAscending;
-                }
-                Sort::Shuffle => {
-                    self.displayed_sort = Sort::ArtistDescending;
-                }
+                Sort::ByTitleAscending => self.displayed_sort = Sort::Shuffle,
+                Sort::ByTitleDescending => self.displayed_sort = Sort::ByTitleAscending,
+                Sort::ByDurationAscending => self.displayed_sort = Sort::ByTitleDescending,
+                Sort::ByDurationDescending => self.displayed_sort = Sort::ByDurationAscending,
+                Sort::ArtistAscending => self.displayed_sort = Sort::ByDurationDescending,
+                Sort::ArtistDescending => self.displayed_sort = Sort::ArtistAscending,
+                Sort::Shuffle => self.displayed_sort = Sort::ArtistDescending,
             },
             // ThisMusic -> AllMusics -> Dont
             PowerActions::Repeat => match self.displayed_repeat {
-                Repeat::SameMusic => {
-                    self.displayed_repeat = Repeat::Dont;
-                }
-                Repeat::AllMusics => {
-                    self.displayed_repeat = Repeat::SameMusic;
-                }
-                Repeat::Dont => {
-                    self.displayed_repeat = Repeat::AllMusics;
-                }
+                Repeat::SameMusic => self.displayed_repeat = Repeat::Dont,
+                Repeat::AllMusics => self.displayed_repeat = Repeat::SameMusic,
+                Repeat::Dont => self.displayed_repeat = Repeat::AllMusics,
             },
             _ => {}
         }
@@ -1834,12 +2029,21 @@ impl<'a> UI<'a> {
         match mode {
             ListMode::Select => {
                 self.geometry.disable_search();
-                self.swap_list_index_to_normal_mode();
+                self.geometry.disable_command();
+                match self.mode {
+                    ListMode::Command => self.swap_list_index_to_normal_from_command(),
+                    ListMode::Search => self.swap_list_index_to_normal_from_search(),
+                    ListMode::AfterSearch => self.swap_list_index_to_normal_from_aftersearch(),
+                    _ => {}
+                }
                 self.reset_querry()
             }
             ListMode::Search => {
                 self.geometry.enable_search();
                 self.swap_list_index_to_search_mode();
+            }
+            ListMode::Command => {
+                self.geometry.enable_command();
             }
             _ => {}
         }
@@ -1940,7 +2144,16 @@ impl<'a> UI<'a> {
         self.region = Region::Lyrics;
     }
 
+    fn select_region(&mut self, region: Region) {
+        self.region = region;
+    }
+
+    fn select_playlist_region(&mut self) {
+        self.region = Region::Playlist;
+    }
+
     fn toggle_lyrics(&mut self) {
+        self.disable_playlists();
         self.displayed_lyrics.displayable = !self.displayed_lyrics.displayable;
         self.geometry.toggle_lyrics();
     }
@@ -2010,46 +2223,19 @@ impl<'a> UI<'a> {
     fn cycle(&mut self) {
         match self.action {
             PowerActions::Sort => match self.displayed_sort {
-                Sort::ByTitleAscending => {
-                    self.displayed_sort = Sort::ByTitleDescending;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::ByTitleDescending => {
-                    self.displayed_sort = Sort::ByDurationAscending;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::ByDurationAscending => {
-                    self.displayed_sort = Sort::ByDurationDescending;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::ByDurationDescending => {
-                    self.displayed_sort = Sort::ArtistAscending;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::ArtistAscending => {
-                    self.displayed_sort = Sort::ArtistDescending;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::ArtistDescending => {
-                    self.displayed_sort = Sort::Shuffle;
-                    // self.music_list.sort(Some(self.sort));
-                }
-                Sort::Shuffle => {
-                    self.displayed_sort = Sort::ByTitleAscending;
-                    // self.music_list.sort(Some(self.sort));
-                }
+                Sort::ByTitleAscending => self.displayed_sort = Sort::ByTitleDescending,
+                Sort::ByTitleDescending => self.displayed_sort = Sort::ByDurationAscending,
+                Sort::ByDurationAscending => self.displayed_sort = Sort::ByDurationDescending,
+                Sort::ByDurationDescending => self.displayed_sort = Sort::ArtistAscending,
+                Sort::ArtistAscending => self.displayed_sort = Sort::ArtistDescending,
+                Sort::ArtistDescending => self.displayed_sort = Sort::Shuffle,
+                Sort::Shuffle => self.displayed_sort = Sort::ByTitleAscending,
             },
             // ThisMusic -> AllMusics -> Dont
             PowerActions::Repeat => match self.displayed_repeat {
-                Repeat::SameMusic => {
-                    self.displayed_repeat = Repeat::AllMusics;
-                }
-                Repeat::AllMusics => {
-                    self.displayed_repeat = Repeat::Dont;
-                }
-                Repeat::Dont => {
-                    self.displayed_repeat = Repeat::SameMusic;
-                }
+                Repeat::SameMusic => self.displayed_repeat = Repeat::AllMusics,
+                Repeat::AllMusics => self.displayed_repeat = Repeat::Dont,
+                Repeat::Dont => self.displayed_repeat = Repeat::SameMusic,
             },
             _ => {}
         }
@@ -2059,7 +2245,18 @@ impl<'a> UI<'a> {
         self.state.batch.repeat = self.state.proxy.get_repeat().await.unwrap_or_default();
     }
 
-    fn swap_list_index_to_normal_mode(&mut self) {
+    fn swap_list_index_to_normal_from_command(&mut self) {
+        self.music_list.switch_selected_buffer = self.music_list.selected;
+        self.music_list.switch_selected_buffer = 0
+    }
+
+    fn swap_list_index_to_normal_from_aftersearch(&mut self) {
+        self.music_list.switch_selected_buffer = self.music_list.selected;
+        self.music_list.selected = 0;
+        self.music_list.switch_selected_buffer = 0
+    }
+
+    fn swap_list_index_to_normal_from_search(&mut self) {
         self.music_list.switch_selected_buffer = self.music_list.selected;
         self.music_list.selected = 0;
         self.music_list.switch_selected_buffer = 0
@@ -2069,46 +2266,212 @@ impl<'a> UI<'a> {
         self.music_list.selected = self.music_list.switch_selected_buffer;
         self.music_list.switch_selected_buffer = 0
     }
-}
 
-#[derive(
-    PartialEq,
-    Eq,
-    Debug,
-    Ord,
-    PartialOrd,
-    Clone,
-    serde::Serialize,
-    serde::Deserialize,
-    zbus::zvariant::Type,
-)]
-pub struct Music {
-    pub title: String,
-    pub length: Duration,
-    pub path: FilePath<'static>,
-    pub artist: String,
-    pub genre: String,
-    pub index: usize,
-}
+    fn disable_playlists(&mut self) {
+        self.displayed_playlists.displayable = false;
+        self.geometry.disable_playlists();
+    }
 
-impl Default for Music {
-    fn default() -> Self {
-        Self {
-            title: String::new(),
-            length: Duration::ZERO,
-            path: FilePath::default(),
-            artist: String::new(),
-            genre: String::new(),
-            index: 0,
+    fn disable_lyrics(&mut self) {
+        self.displayed_lyrics.displayable = false;
+        self.geometry.disable_lyrics();
+    }
+
+    fn toggle_playlists(&mut self) {
+        self.disable_lyrics();
+        self.displayed_playlists.displayable = !self.displayed_playlists.displayable;
+        self.geometry.toggle_playlists();
+    }
+
+    fn render_playlists(&mut self, frame: &mut Frame<'_>) {
+        if self.displayed_playlists.displayable {
+            match self.geometry.playlists_geo() {
+                Some(geo) => {
+                    let names = self.state.playlist_names();
+
+                    let names = names
+                        .iter()
+                        .map(|v| Row::new(vec![v.as_str()]))
+                        .collect::<Vec<Row<'_>>>();
+
+                    let widths = [Constraint::Fill(4)];
+
+                    let style = match self.region {
+                        Region::Lyrics => {
+                            Style::new().fg(self.style.playlists_style.active_region_color)
+                        }
+                        _ => Style::new().fg(self.style.playlists_style.passive_region_color),
+                    };
+
+                    let block = match self.region {
+                        Region::Playlist => Block::default()
+                            .title("Playlists")
+                            .borders(Borders::ALL)
+                            .fg(self.style.playlists_style.active_region_color),
+                        _ => Block::default()
+                            .title("Playlists")
+                            .borders(Borders::ALL)
+                            .fg(self.style.playlists_style.passive_region_color),
+                    };
+
+                    let table = Table::new(names, widths)
+                        .block(block)
+                        .style(style)
+                        .highlight_symbol(self.style.playlists_style.selector.as_str())
+                        .highlight_style(
+                            Style::new()
+                                .add_modifier(Modifier::REVERSED)
+                                .fg(self.style.list_style.hilight_color),
+                        );
+                    frame.render_stateful_widget(table, geo, &mut self.displayed_playlists.state)
+                }
+                None => {}
+            }
         }
     }
-}
 
-#[derive(PartialEq, Eq, Debug, Ord, PartialOrd, Clone, Default)]
-// #[derive(serde::Serialize, serde::Deserialize, zbus::zvariant::Type)]
-pub struct Line {
-    content: String,
-    timestamp: Duration,
+    fn select_next_playlist_name(&mut self) {
+        self.displayed_playlists.state.select_next();
+    }
+
+    fn select_previous_playlist_name(&mut self) {
+        self.displayed_playlists.state.select_previous();
+    }
+
+    async fn switch_to_selected_playlist(&mut self) {
+        if let Some(index) = self.displayed_playlists.state.selected() {
+            let titles = self.state.playlist_names();
+            let title = titles.get(index).unwrap();
+            let _ = self.state.proxy.use_playlist(title.clone()).await;
+        }
+    }
+
+    fn render_commands(&self, frame: &mut Frame<'_>) {
+        if matches!(self.mode, ListMode::Command) {
+            if let Some(geo) = self.geometry.command_geo() {
+                frame.render_widget(
+                    Paragraph::new(self.command_bufr.value())
+                        .block(Block::bordered().title("Command")),
+                    geo,
+                );
+            }
+        }
+    }
+
+    async fn run_command(&mut self) -> std::io::Result<bool> {
+        let command = self.command_bufr.to_string();
+        let mut commands: Vec<String> = command.split_whitespace().map(|v| v.to_string()).collect();
+        if commands.len() > 0 {
+            let command_name = commands.remove(0);
+            let command_args = commands;
+            match CommandName::from_str(&command_name) {
+                Ok(name) => return self.preform(CommandContext::new(name, command_args)).await,
+                Err(e) => todo!("{:?}", e),
+            }
+        }
+        Ok(false)
+    }
+
+    fn render_search(&self, frame: &mut Frame<'_>) {
+        if matches!(self.mode, ListMode::Search | ListMode::AfterSearch) {
+            if let Some(geo) = self.geometry.search_geo() {
+                frame.render_widget(
+                    Paragraph::new(self.search_bufr.value())
+                        .block(Block::bordered().title("Querry")),
+                    geo,
+                );
+            }
+        }
+    }
+
+    async fn preform(&mut self, context: CommandContext) -> Result<bool, io::Error> {
+        let args = context.args;
+        if args.len() > context.name.number_of_required_args() {
+            return Err(std::io::Error::other("Too many arguments"));
+        } else if args.len() < context.name.number_of_required_args() {
+            return Err(std::io::Error::other("Few arguments"));
+        }
+        match context.name {
+            CommandName::Play => {
+                // guarded by upper if check
+                let direction = args.get(0).unwrap();
+                match direction.as_str() {
+                    "previous" => self.play_preivous().await,
+                    "next" => self.play_next().await,
+                    _ => {}
+                }
+            }
+            CommandName::Move => {
+                // guarded by upper if check
+                let direction = args.get(0).unwrap();
+                match direction.as_str() {
+                    "up" => self.list_up(),
+                    "down" => self.list_down(),
+                    _ => {}
+                }
+            }
+            CommandName::AddToPlaylist => {
+                let name = args.get(0).unwrap();
+                self.add_selected_to_playlist(name).await;
+            }
+            CommandName::Quit => return Ok(true),
+            CommandName::CreatePlaylist => {
+                let name = args.get(0).unwrap();
+                self.crate_playlist(name).await;
+            }
+            CommandName::ToggleMute => self.toggle_mute().await,
+            CommandName::Pause => self.state.pause_stream(),
+            CommandName::Resume => self.state.resume_stream(),
+            CommandName::Reload => self.reload().await,
+            CommandName::RenamePlaylist => {
+                let old = args.get(0).unwrap();
+                let new = args.get(1).unwrap();
+                self.rename_playlist(old, new).await;
+            }
+            CommandName::RemovePlaylist => {
+                let name = args.get(0).unwrap();
+                self.remove_playlist(name).await;
+            }
+        }
+        Ok(false)
+    }
+
+    async fn add_selected_to_playlist(&self, destination: &String) {
+        let index = self
+            .music_list
+            .musics
+            .get(self.music_list.selected)
+            .unwrap()
+            .index;
+
+        let source = self.state.proxy.get_playlist_name().await.unwrap();
+
+        self.state
+            .proxy
+            .save_to_playlist(index, source.clone(), destination.clone())
+            .await
+            .unwrap();
+    }
+
+    async fn crate_playlist(&self, name: &String) {
+        self.state
+            .proxy
+            .create_playlist(name.clone())
+            .await
+            .unwrap();
+    }
+
+    async fn rename_playlist(&self, old: &str, new: &str) {
+        self.state.proxy.rename_playlist(old, new).await.unwrap();
+    }
+
+    async fn remove_playlist(&self, name: &str) {
+        self.state.proxy.remove_playlist(name).await.unwrap();
+    }
+
+    async fn reload(&self) {
+        self.state.proxy.reload_config().await.unwrap();
+    }
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -2120,7 +2483,25 @@ pub struct DisplayedLyrics {
     state: TableState,
     /// Lyrics
     lyrics: Lyrics,
+    /// Used to sync current lyrics line with the audio
     pub last_active_interaction: Instant,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisplayedPlaylists {
+    /// Used to toggle playlists view
+    displayable: bool,
+    /// State/Index of the playlist list pointer
+    state: TableState,
+}
+
+impl Default for DisplayedPlaylists {
+    fn default() -> Self {
+        Self {
+            displayable: false,
+            state: TableState::default(),
+        }
+    }
 }
 
 impl Default for DisplayedLyrics {
@@ -2143,7 +2524,8 @@ pub struct Musics {
     pub musics: Vec<Music>,
     /// index of the currently *selected* music in the displayed music list
     pub selected: usize,
-    /// buffer used to switch between selected index values
+    /// Buffer used to switch between selected index values
+    /// Holds the previously selected index
     /// search/aftersearch <===> normal
     pub switch_selected_buffer: usize,
     pub state: TableState,
@@ -2155,7 +2537,7 @@ pub struct Musics {
 }
 
 impl Musics {
-    /// search the music list wit respect to the search buffer and
+    /// search the music list
     pub fn search(&mut self, search_bufr: String) {
         let n = 20;
         let paire = search_bufr.split_once(":");
@@ -2184,15 +2566,11 @@ impl Musics {
                 }
             }
             None => {
-                if search_bufr.is_empty() {
-                    // self.musics = self.full_que.clone();
-                } else {
-                    self.musics = fuzzy_search::fuzzy_search_music_titles_best_n(
-                        &search_bufr,
-                        &self.unfiltered_music_list,
-                        n,
-                    );
-                }
+                self.musics = fuzzy_search::fuzzy_search_music_titles_best_n(
+                    &search_bufr,
+                    &self.unfiltered_music_list,
+                    n,
+                );
             }
         }
     }
@@ -2217,7 +2595,6 @@ pub enum PowerActions {
     Stop,
 }
 
-//  TODO: use the '<command>: <arg>' for commands
 #[derive(Deserialize, Serialize, Clone, Copy)]
 enum Kmodifier {
     SHIFT,


### PR DESCRIPTION
# Description

- New `commands` window with multiple new commands, these commands can be used to preform a varient of new tasks (move selector, create playlist, select playlist, add a music to a playlist, pause, resume, quit, etc.)
- New playlist management system with keybind to toggle the palylist view and enter to select a given playlist.
- Proper build args for nix flake.
- Use version defined crates instead of remote/master for zbus.
- Other minimum bug fixes

# Commits:

- **feat: playlist management system**
- **chor: use stable crate releases for zbus**
- **fix: proper nix build args pass for naersk**

# Note
- This works only with `mplayer-server v0.1.1` or higher!
